### PR TITLE
Re-depend on VS version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @h-vetinari @mbargull
+* @h-vetinari @isuruf @mbargull

--- a/README.md
+++ b/README.md
@@ -195,5 +195,6 @@ Feedstock Maintainers
 =====================
 
 * [@h-vetinari](https://github.com/h-vetinari/)
+* [@isuruf](https://github.com/isuruf/)
 * [@mbargull](https://github.com/mbargull/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not win]
 
 outputs:
@@ -48,7 +48,7 @@ outputs:
         - m2-bash
         - m2-coreutils
         - m2-sed
-        - vs_win-64
+        - {{ compiler("c") }}
     test:
       requires:
         # Some random packages that have exe files not under %PREFIX%\Scripts.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,3 +96,4 @@ extra:
   recipe-maintainers:
     - mbargull
     - h-vetinari
+    - isuruf


### PR DESCRIPTION
From post-merge feedback in #2

> The exact compiler pin was because there's no transitive run_exports and we need to match the run_exports of the compiler in symlink-exe-runtime. Please don't remove this. Instead, please bump the compiler version.

@isuruf, if you want to join as maintainer here, that would be great!